### PR TITLE
66% improved performance on Kepler (K80)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 CC = nvcc
 MPCC = nvcc
 OPENMP = 
-CFLAGS = -O3 -arch sm_20 g
-NVCCFLAGS = -g -O3 -arch sm_20
+CFLAGS = -O3
+NVCCFLAGS = -O3 -arch sm_35
 LIBS = -lm
 
 all: henry henry_serial

--- a/henry.cu
+++ b/henry.cu
@@ -53,9 +53,9 @@ int ncycles = floor(ninsertions / (NUMTHREADS * NUMBLOCKS));
 //   Find nearest image to methane at point (x, y, z) for application of periodic boundary conditions
 //   Compute energy contribution due to this atom via the Lennard-Jones potential
 __device__ double ComputeBoltzmannFactorAtPoint(double x, double y, double z,
-                                       StructureAtom * structureatoms,
-                                       double natoms,
-                                       double L) {
+                                                const StructureAtom * __restrict__ structureatoms,
+                                                double natoms,
+                                                double L) {
     // (x, y, z) : Cartesian coords of methane molecule
     // structureatoms : pointer array storing info on unit cell of crystal structure
     // natoms : number of atoms in crystal structure
@@ -98,7 +98,10 @@ __device__ double ComputeBoltzmannFactorAtPoint(double x, double y, double z,
 // Inserts a methane molecule at a random position inside the structure
 // Calls function to compute Boltzmann factor at this point
 // Stores Boltzmann factor computed at this thread in deviceBoltzmannFactors
-__global__ void PerformInsertions(curandStateMtgp32 *state, double * deviceBoltzmannFactors, StructureAtom * structureatoms, int natoms, double L) {
+__global__ void PerformInsertions(curandStateMtgp32 *state, 
+                                  double * __restrict__ deviceBoltzmannFactors, 
+                                  const StructureAtom * __restrict__ structureatoms, 
+                                  int natoms, double L) {
     // state : random number generator
     // deviceBoltzmannFactors : pointer array in which to store computed Boltzmann factors
     // structureatoms : pointer array storing info on unit cell of crystal structure

--- a/henry.cu
+++ b/henry.cu
@@ -99,7 +99,7 @@ __device__ double ComputeBoltzmannFactorAtPoint(double x, double y, double z,
 // Calls function to compute Boltzmann factor at this point
 // Stores Boltzmann factor computed at this thread in deviceBoltzmannFactors
 __global__ void PerformInsertions(curandStateMtgp32 *state, 
-                                  double * __restrict__ deviceBoltzmannFactors, 
+                                  double * deviceBoltzmannFactors, 
                                   const StructureAtom * __restrict__ structureatoms, 
                                   int natoms, double L) {
     // state : random number generator


### PR DESCRIPTION
1. There's no real need to have a **device** variable for the T and and K variables, if you just define it const -- it's a constant literal that the compiler will inline anyway. 
2. Using rsqrt and multiply instead of sqrt and divide is faster.
3. Marking the Structureatoms pointer const and **restrict** allows Kepler to use the LDG instruction to access memory through the "read only data cache", which gives about a 35% speedup.
